### PR TITLE
Added handling of forwarded paths without an Internal Server

### DIFF
--- a/src/datarobot_asgi_middleware/__init__.py
+++ b/src/datarobot_asgi_middleware/__init__.py
@@ -55,13 +55,13 @@ class DataRobotASGIMiddleware:
         if x_forwarded_prefix:
             # Getting a request originating from the external load balancer.
             scope["root_path"] = x_forwarded_prefix + scope["root_path"]
-            if not scope["path"].startswith(x_forwarded_prefix) and not self.internal_prefix:
-                # The path does not start with the x-forwarded-prefix, so we need to rewrite it.
-                scope["path"] = x_forwarded_prefix + scope["path"]
+
             if self.internal_prefix and scope["path"].startswith(self.internal_prefix):
-                # But it is getting proxied through the internal load balancer, so we need to
-                # rewrite the path to match the external load balancer.
+                # Replace internal prefix with external prefix
                 scope["path"] = scope["path"].replace(self.internal_prefix, x_forwarded_prefix, 1)
+            elif not scope["path"].startswith(x_forwarded_prefix):
+                # Add external prefix to path
+                scope["path"] = x_forwarded_prefix + scope["path"]
             return await self.app(scope, receive, send)
 
         return await self.app(scope, receive, send)

--- a/src/datarobot_asgi_middleware/__init__.py
+++ b/src/datarobot_asgi_middleware/__init__.py
@@ -55,6 +55,9 @@ class DataRobotASGIMiddleware:
         if x_forwarded_prefix:
             # Getting a request originating from the external load balancer.
             scope["root_path"] = x_forwarded_prefix + scope["root_path"]
+            if not scope["path"].startswith(x_forwarded_prefix) and not self.internal_prefix:
+                # The path does not start with the x-forwarded-prefix, so we need to rewrite it.
+                scope["path"] = x_forwarded_prefix + scope["path"]
             if self.internal_prefix and scope["path"].startswith(self.internal_prefix):
                 # But it is getting proxied through the internal load balancer, so we need to
                 # rewrite the path to match the external load balancer.

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -161,6 +161,14 @@ def test_static_files_with_external_proxy(app, tmp_path):
     assert response.status_code == 200
     assert response.text == "test content"
 
+   # Access through external proxy with prefix
+    response = client.get(
+        "/assets/test.txt",
+        headers={"x-forwarded-prefix": "/custom_applications/67f3e8ac039772f090878752"}
+    )
+    assert response.status_code == 200
+    assert response.text == "test content"
+
 
 def test_static_files_with_internal_prefix(app, tmp_path, monkeypatch):
     # Set up the internal prefix via SCRIPT_NAME


### PR DESCRIPTION
## Summary

We are missing one use case where you receive the sub-url but the path does not include it


## Rationale
